### PR TITLE
エントリ用のスクリプトファイルの設定

### DIFF
--- a/bin/saider
+++ b/bin/saider
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/server');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-require('./lib/server');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "npm run build; NODE_ENV=production node lib/server.js",
-    "dev": "npm run build; node .",
+    "dev": "npm run build; node lib/server.js",
     "build": "babel src -d lib",
     "lint": "eslint src",
     "cleanroom": "node scripts/clean.js"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "Saider",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A interactive dice bot",
-  "main": "index.js",
+  "main": "src/server.js",
+  "bin": {
+    "saider": "./lib/saider"
+  },
   "scripts": {
     "start": "npm run build; NODE_ENV=production node .",
     "dev": "npm run build; node .",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "saider": "./lib/saider"
   },
   "scripts": {
-    "start": "npm run build; NODE_ENV=production node .",
+    "start": "npm run build; NODE_ENV=production node lib/server.js",
     "dev": "npm run build; node .",
     "build": "babel src -d lib",
     "lint": "eslint src",


### PR DESCRIPTION
今後、ユーザが利用する際には `git clone` ではなく `npm install` 経由で利用する事を標準とした方が望ましいと考えたのでそれ用の修正を以下2点行いました  

 - cli用のスクリプトを `./bin` に配置  
    `npm install` 経由であればこの修正で `saider` コマンドでサーバを起動できるようになります  
 - mainに直接 `lib/server.js` を指定  
    `index.js` はほぼ不要(実質lib/server.jsへのリンク)なので main スクリプトを直接 `lib/server.js` に置き換えました