### PR TITLE
ES Modules の export 方法を修正

### DIFF
--- a/src/datastore.js
+++ b/src/datastore.js
@@ -5,7 +5,7 @@ const key = (target, id) => {
     return target + '.' + id;
 };
 
-class DataStore {
+export default class DataStore {
     constructor(config) {
         client = redis.createClient(config.redis);
     }
@@ -169,5 +169,3 @@ class DataStore {
         });
     }
 }
-
-export { DataStore };

--- a/src/dicebot/cthulhu.js
+++ b/src/dicebot/cthulhu.js
@@ -1,7 +1,7 @@
 import util from './module/util.js';
 import DiceBot from './dicebot.js';
 
-class Cthulhu extends DiceBot {
+export default class Cthulhu extends DiceBot {
     constructor(){
         super();
         this.name = 'クトゥフル神話TRPG';
@@ -184,5 +184,3 @@ x=故障ナンバー。出目x以上が出た場合、判定の成否と故障�
         return {dices: [dice], total: total, result: result};
     }
 }
-
-export default Cthulhu;

--- a/src/dicebot/dicebot.js
+++ b/src/dicebot/dicebot.js
@@ -1,6 +1,6 @@
 import util from './module/util.js';
 
-class DiceBot {
+export default class DiceBot {
     constructor(){
         /* name : ダイスボット名 */
         this.name = '標準ダイスボット';
@@ -148,5 +148,3 @@ class DiceBot {
         return res;
     }
 }
-
-export default DiceBot;

--- a/src/dicebot/module/util.js
+++ b/src/dicebot/module/util.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-function getDicebotPaths() {
+export function getDicebotPaths() {
     var fileList = [];
     fs.readdir('./lib/dicebot', function(err, files){
         if (err) throw err;
@@ -13,7 +13,7 @@ function getDicebotPaths() {
     return fileList;
 }
 
-function rollDice(n, d) {
+export function rollDice(n, d) {
     var numbers = [];
     var total = 0;
 
@@ -41,21 +41,18 @@ function rollDice(n, d) {
         }
     }
 
-    var result = {
+    return {
         n: n,
         d: d,
         numbers: numbers,
         total: total,
     };
-    return result;
 }
 
-const basic_request_reg = /^\d*[dD]\d+(([+-]\d*[dD]\d+)|([+-]\d+))*([<>]=?\d+)?$/;
+export const basic_request_reg = /^\d*[dD]\d+(([+-]\d*[dD]\d+)|([+-]\d+))*([<>]=?\d+)?$/;
 
-let util = {
+export default {
     getDicebotPaths,
     rollDice,
     basic_request_reg,
 };
-
-export default util;

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,4 +1,6 @@
-function escapeHTML(str) {
+import crypto from 'crypto';
+
+export function escapeHTML(str) {
     str = str.replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -7,30 +9,27 @@ function escapeHTML(str) {
     return str;
 }
 
-function cspParams(host) {
+export function cspParams(host) {
     'default-src "self" ' + host + ' ws://' + host + '; img-src "self" *';
 }
 
-import crypto from 'crypto';
 const seed = Date.now() * Math.random();
 let serial = 1;
 
-function generateId() {
+export function generateId() {
     const data = seed + ':' + serial++;
     return crypto.createHash('sha1').update(data).digest('hex');
 }
 
-function passwordToHash(password) {
+export function passwordToHash(password) {
     let sha512 = crypto.createHash('sha512');
     sha512.update(password);
     return sha512.digest('hex');
 }
 
-let helper = {
+export default {
     escapeHTML,
     cspParams,
     generateId,
-    passwordToHash,
+    passwordToHash
 };
-
-export default helper;

--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,11 @@
-import helper from './helper';
+import {cspParams, escapeHTML, generateId, passwordToHash} from './helper';
 var config = (process.env.NODE_ENV === 'production')
         ? require('../config.json')
         : require('../config.dev.json');
 
 /* datastore */
 
-import { DataStore } from './datastore';
+import DataStore from './datastore';
 var datastore = new DataStore(config);
 var room_dicebot = {};
 datastore.getAllDicebot(function(dicebots) {
@@ -39,7 +39,7 @@ var ectRenderer = ECT({ watch: true, root: __dirname + '/views', ext : '.ect' })
 app.engine('ect', ectRenderer.render);
 app.set('view engine', 'ect');
 
-var headerCSP = helper.cspParams(config.host);
+var headerCSP = cspParams(config.host);
 
 app.get('/*', function(req,res,next) {
     res.header('X-XSS-Protection', '1; mode=block');
@@ -53,19 +53,19 @@ app.get('/', function(req, res) {
             rooms: rooms,
             passwords: passwords,
             dicebot: dicebotList,
-            escape: helper.escapeHTML,
+            escape: escapeHTML,
         });
     });
 });
 
 app.post('/create-room', function (req, res) {
-    var room_id = helper.generateId();
+    var room_id = generateId();
     var room_name = req.param('room-name');
     var room_password = req.param('room-password');
     var dicebot_id = req.param('dicebot');
 
     if (room_password != '') {
-        var hash = helper.passwordToHash(room_password);
+        var hash = passwordToHash(room_password);
         datastore.setPassword(room_id, hash);
     }
 
@@ -95,7 +95,7 @@ app.get('/:room_id', function(req, res) {
                     is_need_password: is_need_password,
                     dicebots: dicebotList,
                     dicebot: room_dicebot[room_id],
-                    escape: helper.escapeHTML,
+                    escape: escapeHTML,
                 });
             });
         }
@@ -126,7 +126,7 @@ io.sockets.on('connection', function(socket) {
             }
 
             datastore.getPassword(user.room, function (err, pass) {
-                if (pass == null || pass == helper.passwordToHash(user.password)) {
+                if (pass == null || pass == passwordToHash(user.password)) {
                     socket.emit('accepted');
 
                     datastore.getAllResult(user.room, function (err, results) {


### PR DESCRIPTION
ES Modules でモジュール化されているスクリプトの export 方法を一般的なやり方に寄せた修正を行いました。  

主な方針は以下の３点です  

 - class の公開はそれ自体を `default` として export する  
 - 関数の集合を公開する場合はラッパーオブジェクトを `default` として export する  
 - また、個々の関数を個別に export する   

export キーワードはなるべく対象の宣言と同時に行うようにしています(これはほとんど書き方だけの問題ですが、ある程度スタンダードな記法として定着しているので倣っています)