### PR TITLE
use escape-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-es2015-node6": "0.3.0",
     "body-parser": "1.15.2",
     "ect": "0.5.9",
+    "escape-html": "1.0.3",
     "express": "4.14.0",
     "redis": "2.6.2",
     "socket.io": "1.5.1"

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,14 +1,5 @@
 import crypto from 'crypto';
 
-export function escapeHTML(str) {
-    str = str.replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-    return str;
-}
-
 export function cspParams(host) {
     'default-src "self" ' + host + ' ws://' + host + '; img-src "self" *';
 }
@@ -28,7 +19,6 @@ export function passwordToHash(password) {
 }
 
 export default {
-    escapeHTML,
     cspParams,
     generateId,
     passwordToHash

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
-import {cspParams, escapeHTML, generateId, passwordToHash} from './helper';
+import {cspParams, generateId, passwordToHash} from './helper';
+const escapeHTML = require('escape-html');
 var config;
 var port = 31102;
 


### PR DESCRIPTION
HTMLのエスケープ処理を自前のコードではなく[escape-html](https://www.npmjs.com/package/escape-html)を利用するように改修しました。

エスケープ処理として差異はなく、正規表現を使っていない分若干の高速化も見込めるため(現実的に有為な影響は出ないと思いますが…)こちらを利用した方が良いと思います。