### PR TITLE
use common-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015-node6": "0.3.0",
     "body-parser": "1.15.2",
+    "common-tags": "1.4.0",
     "ect": "0.5.9",
     "express": "4.14.0",
     "redis": "2.6.2",

--- a/src/dicebot/cthulhu.js
+++ b/src/dicebot/cthulhu.js
@@ -1,3 +1,4 @@
+import {stripIndent} from 'common-tags';
 import util from './module/util.js';
 import DiceBot from './dicebot.js';
 
@@ -6,36 +7,36 @@ export default class Cthulhu extends DiceBot {
         super();
         this.name = 'クトゥフル神話TRPG';
 
-        this.description = `
-c=クリティカル値 ／ f=ファンブル値 ／ s=スペシャル
-
-1d100<=n  1d100ロールを行う c=1、f=100
-
-・cfs判定付き判定コマンド
-
-CC   1d100ロールを行う c=1、f=100
-CCB  同上、c=5、f=96
-
-例：CC<=80  （技能値80で行為判定。1%ルールでcf適用）
-例：CCB<=55 （技能値55で行為判定。5%ルールでcf適用）
-
-・組み合わせロールについて
-
-CBR(x,y)  c=1、f=100
-CBRB(x,y) c=5、f=96
-
-・抵抗表ロールについて
-RES(x-y)  c=1、f=100
-RESB(x-y) c=5、f=96
-
-※故障ナンバー判定
-
-・CC(x) c=1、f=100
-x=故障ナンバー。出目x以上が出た場合、判定の成否と故障を共に出力する。("成功/故障", "失敗/故障")
-故障した場合にはcfs判定は行わない。
-
-・CCB(x) c=5、f=96
-同上`;
+        this.description = stripIndent`
+            c=クリティカル値 ／ f=ファンブル値 ／ s=スペシャル
+            
+            1d100<=n  1d100ロールを行う c=1、f=100
+            
+            ・cfs判定付き判定コマンド
+            
+            CC   1d100ロールを行う c=1、f=100
+            CCB  同上、c=5、f=96
+            
+            例：CC<=80  （技能値80で行為判定。1%ルールでcf適用）
+            例：CCB<=55 （技能値55で行為判定。5%ルールでcf適用）
+            
+            ・組み合わせロールについて
+            
+            CBR(x,y)  c=1、f=100
+            CBRB(x,y) c=5、f=96
+            
+            ・抵抗表ロールについて
+            RES(x-y)  c=1、f=100
+            RESB(x-y) c=5、f=96
+            
+            ※故障ナンバー判定
+            
+            ・CC(x) c=1、f=100
+            x=故障ナンバー。出目x以上が出た場合、判定の成否と故障を共に出力する。("成功/故障", "失敗/故障")
+            故障した場合にはcfs判定は行わない。
+            
+            ・CCB(x) c=5、f=96
+            同上`;
 
         this.prefix = ['choice', 'cc', 'ccb', 'res', 'resb', 'cbr', 'cbrb'];
         this.infix = [];

--- a/src/dicebot/dicebot.js
+++ b/src/dicebot/dicebot.js
@@ -1,3 +1,4 @@
+import {stripIndent} from 'common-tags';
 import util from './module/util.js';
 
 export default class DiceBot {
@@ -6,12 +7,12 @@ export default class DiceBot {
         this.name = '標準ダイスボット';
 
         /* description : ダイスボットの説明や使用例 */
-        this.description = `
-例：
-3d6
-1D100 <= 50
-3d6 + 1d4
-1d6 + 3`;
+        this.description = stripIndent`
+            例：
+            3d6
+            1D100 <= 50
+            3d6 + 1d4
+            1d6 + 3`;
 
         this.prefix = ['choice'];
         this.infix = [];

--- a/src/server.js
+++ b/src/server.js
@@ -4,8 +4,8 @@ var port = 31102;
 
 if (process.env.ON_HEROKU === 'true') {
     config = {
-        "host": process.env.HEROKU_APP_NAME + ".herokuapp.com"
-    }
+        "host": `${process.env.HEROKU_APP_NAME}.herokuapp.com`
+    };
     port = process.env.PORT;
 }
 else {
@@ -46,7 +46,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
 var ECT = require('ect');
-var ectRenderer = ECT({ watch: true, root: __dirname + '/views', ext : '.ect' });
+var ectRenderer = ECT({ watch: true, root: `${__dirname}/views`, ext : '.ect' });
 app.engine('ect', ectRenderer.render);
 app.set('view engine', 'ect');
 
@@ -93,7 +93,7 @@ app.post('/create-room', function (req, res) {
 });
 
 app.get('/licenses', function(req, res) {
-    res.sendFile(__dirname + '/licenses.html');
+    res.sendFile(`${__dirname }/licenses.html`);
 });
 
 app.get('/:room_id', function(req, res) {
@@ -204,7 +204,7 @@ io.sockets.on('connection', function(socket) {
 
         io.sockets.to(socket.room).emit('roll', res);
 
-        var result_text = request + '→' + (res.total || res.result);
+        var result_text = `${request}→${(res.total || res.result)}`;
         var json = JSON.stringify({name: user_hash[socket.id], text: result_text});
         datastore.setResult(socket.room, json);
     });


### PR DESCRIPTION
tagged-template機能を使って template-literal の機能を拡張する [common-tags](https://www.npmjs.com/package/common-tags) を導入しました。

今回は複数行のドキュメントに対してコードインデントを出力時にommitできる `stripIndent` を利用してダイスボットのHelpメッセージを書き直しています。

個人的にはRubyやCoffeScriptのヒアドキュメントと同等に書けるので好ましいと感じています。
合わせて、変数と結合する文字列はなるべく template-literal で統一するように修正しています。

原則、今後は文字列の結合処理は全て template-literal に統一すべきと考えています。