### PR TITLE
#14 fixed

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -1,3 +1,4 @@
 {
-  "host" : "localhost:31102"
+  "hostname" : "localhost",
+  "port": 31102
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,6 @@
 {
-  "host" : "example.net",
+  "hostname" : "example.net",
+  "port" : 80,
   "redis" : {
     "host": "saider_redis_1",
     "path" : "/path/to/redis.sock"

--- a/src/helper.js
+++ b/src/helper.js
@@ -14,7 +14,12 @@ export function passwordToHash(password) {
     return sha512.digest('hex');
 }
 
+export function either(value) {
+    return (option) => value ? value : option
+}
+
 export default {
+    either,
     generateId,
     passwordToHash
 };

--- a/src/server.js
+++ b/src/server.js
@@ -1,16 +1,22 @@
 const url = require('url');
-import {generateId, passwordToHash} from './helper';
+import {either, generateId, passwordToHash} from './helper';
 const escapeHTML = require('escape-html');
+
+const DEFAULT_HOSTNAME = '0.0.0.0';
+const DEFAULT_PORT = 80;
 let config;
 
 if (process.env.ON_HEROKU === 'true') {
-    config = { host: `${process.env.HEROKU_APP_NAME}.herokuapp.com:${process.env.PORT || 31102}` };
+    const {env: {HEROKU_APP_NAME, PORT}} = process;
+    config = { host: `${HEROKU_APP_NAME}.herokuapp.com:${PORT || DEFAULT_PORT}` };
 }
 else {
     config = (process.env.NODE_ENV === 'production')
         ? require('../config.json')
         : require('../config.dev.json');
 }
+
+if(!config.host) config.host = `${either(config.hostname)(DEFAULT_HOSTNAME)}:${either(config.port)(DEFAULT_PORT)}`;
 
 /* datastore */
 
@@ -118,7 +124,7 @@ app.get('/:room_id', function(req, res) {
 
 app.use(express.static('public'));
 
-server.listen(parseInt(url.parse(config.host).port || 31102), function() {
+server.listen(either(config.port)(DEFAULT_PORT), function() {
     console.log(`listening on ${config.host}`);
 });
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,13 +1,10 @@
+const url = require('url');
 import {cspParams, generateId, passwordToHash} from './helper';
 const escapeHTML = require('escape-html');
-var config;
-var port = 31102;
+let config;
 
 if (process.env.ON_HEROKU === 'true') {
-    config = {
-        "host": process.env.HEROKU_APP_NAME + ".herokuapp.com"
-    }
-    port = process.env.PORT;
+    config = { host: `${process.env.HEROKU_APP_NAME}.herokuapp.com:${process.env.PORT || 31102}` };
 }
 else {
     config = (process.env.NODE_ENV === 'production')
@@ -119,8 +116,8 @@ app.get('/:room_id', function(req, res) {
 
 app.use(express.static('public'));
 
-server.listen(port, function() {
-    console.log('listening on *:31102');
+server.listen(parseInt(url.parse(config.host).port || 31102), function() {
+    console.log(`listening on ${config.host}`);
 });
 
 /* socketio */


### PR DESCRIPTION
`config.host` からサーバプロセスの port を設定するように修正しました。  

[こちらのページの記述にもありますが](https://nodejs.org/dist/latest-v6.x/docs/api/url.html#url_url_strings_and_url_objects)、 `host` は `hostname + port` という定義ですのでheroku用に生成している `config.host` にも port 番号を埋め込むようにしています。